### PR TITLE
Minor Improvements -- Timr1

### DIFF
--- a/swmixer.py
+++ b/swmixer.py
@@ -27,6 +27,10 @@ try:
 except:
     "MP3 streaming disabled"
 
+def Read24(s):
+    for i in range(0,len(s),3):
+        yield ord(s[i+2])*65536 + ord(s[i+1])*256 + ord(s[i])
+
 ginit = False
 gstereo = True
 gchunksize = 1024
@@ -274,6 +278,10 @@ class Sound:
             if wf.getsampwidth() == 2:
                 self.data = numpy.fromstring(''.join(data), 
                                              dtype=numpy.int16)
+            if wf.getsampwidth() == 3:
+                self.data = numpy.array(list(Read24(''.join(data))),
+                                             dtype=numpy.int16)
+                self.data = self.data / 16777216.0
             if wf.getsampwidth() == 4: 
                 self.data = numpy.fromstring(''.join(data), 
                                              dtype=numpy.int32)

--- a/swmixer.py
+++ b/swmixer.py
@@ -610,7 +610,7 @@ def tick(extra=None):
     glock.release()
     odata = (b.astype(numpy.int16)).tostring()
     # yield rather than block, pyaudio doesn't release GIL
-    while gstream.get_write_available() < gchunksize: time.sleep(0.001)
+    while ginit and gstream.get_write_available() < gchunksize: time.sleep(0.001)
     gstream.write(odata, gchunksize)
 
 def init(samplerate=44100, chunksize=1024, stereo=True, microphone=False, input_device_index=None, output_device_index=None):
@@ -668,7 +668,7 @@ def start():
     """Start separate mixing thread"""
     global gthread
     def f():
-        while True:
+        while ginit:
             tick()
             time.sleep(0.001)
     gthread = thread.start_new_thread(f, ())


### PR DESCRIPTION
This changeset adds support for 24-bit PCM wave files, and allows the "tick" loop to exit when the mixer shuts down.  This fixes some odd shutdown problems, like hung thread or null pointer deref in PortAudio.
